### PR TITLE
🚨 ✅ ✔️ Tests/admin

### DIFF
--- a/django_notification/tests/admin/test_deleted_notification_admin.py
+++ b/django_notification/tests/admin/test_deleted_notification_admin.py
@@ -1,0 +1,159 @@
+import sys
+from unittest.mock import Mock
+import pytest
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+from django_notification.models import DeletedNotification
+from django_notification.admin import DeletedNotificationAdmin
+from django_notification.tests.constants import PYTHON_VERSION, PYTHON_VERSION_REASON
+
+pytestmark = [
+    pytest.mark.admin,
+    pytest.mark.admin_deleted_notification,
+    pytest.mark.skipif(sys.version_info < PYTHON_VERSION, reason=PYTHON_VERSION_REASON),
+]
+
+
+@pytest.mark.django_db
+class TestDeletedNotificationAdmin:
+    """
+    Test suite for the DeletedNotificationAdmin class in the Django admin interface.
+    """
+
+    def mock_request(self, user: User) -> Mock:
+        """
+        Create a mock request object with a user for testing.
+
+        Args:
+        ----
+            user: The user to associate with the mock request.
+
+        Returns:
+        -------
+            Mock: A mock request object with the user attribute set.
+        """
+        request = Mock()
+        request.user = user
+        return request
+
+    def test_deleted_notification_admin_list_display(
+        self, admin_user: User, deleted_notification: DeletedNotification
+    ) -> None:
+        """
+        Test that the list display fields in the DeletedNotificationAdmin interface
+        are rendered correctly in the Django admin changelist view.
+
+        Asserts:
+        -------
+            - The changelist view returns a 200 status code.
+            - The list display includes the fields 'notification_id', 'get_title', 'get_deleted_by', and 'deleted_at'.
+        """
+        client = Client()
+        client.login(username="admin", password="password")
+
+        url = reverse("admin:django_notification_deletednotification_changelist")
+        response = client.get(url)
+
+        assert (
+            response.status_code == 200
+        ), "Expected changelist view to return status 200."
+        content = response.content.decode()
+        assert (
+            "notification_id" in content
+        ), "'notification_id' field is missing in the list display."
+        assert (
+            "get_title" in content
+        ), "'get_title' field is missing in the list display."
+        assert (
+            "get_deleted_by" in content
+        ), "'get_deleted_by' field is missing in the list display."
+        assert (
+            "deleted_at" in content
+        ), "'deleted_at' field is missing in the list display."
+
+    def test_deleted_notification_admin_filters(
+        self, admin_user: User, deleted_notification: DeletedNotification
+    ) -> None:
+        """
+        Test that the filters in the DeletedNotificationAdmin interface work correctly.
+
+        Asserts:
+        -------
+            - The filtered changelist view returns a 200 status code.
+            - The changelist view includes the "Deleted Notifications" section.
+        """
+        client = Client()
+        client.login(username="admin", password="password")
+
+        url = reverse("admin:django_notification_deletednotification_changelist")
+        response = client.get(
+            url + "?deleted_at__gte=2024-01-01+00%3A00%3A00%2B00%3A00"
+        )
+
+        assert (
+            response.status_code == 200
+        ), "Expected filtered changelist view to return status 200."
+        assert (
+            "Deleted Notifications" in response.content.decode()
+        ), "'Deleted Notifications' filter not applied."
+
+    def test_deleted_notification_admin_search(
+        self, admin_user: User, user: User, deleted_notification: DeletedNotification
+    ) -> None:
+        """
+        Test the search functionality in DeletedNotificationAdmin for searching by notification ID
+        and username of the user who deleted the notification.
+
+        Asserts:
+        -------
+            - The search by notification ID returns the correct result.
+            - The search by the username of the user who deleted the notification returns the correct result.
+        """
+        admin_site = admin.site
+        model_admin = DeletedNotificationAdmin(DeletedNotification, admin_site)
+        request = self.mock_request(admin_user)
+
+        # Test search by notification ID
+        queryset, _ = model_admin.get_search_results(
+            request,
+            DeletedNotification.objects.all(),
+            deleted_notification.notification.id,
+        )
+        assert (
+            queryset.count() == 1
+        ), "Search by notification ID did not return the expected result."
+
+        # Test search by the username of the user who deleted this notification
+        queryset, _ = model_admin.get_search_results(
+            request, DeletedNotification.objects.all(), user.username
+        )
+        assert (
+            queryset.count() == 1
+        ), "Search by username did not return the expected result."
+
+    def test_deleted_notification_admin_queryset(
+        self, admin_user: User, deleted_notification: DeletedNotification
+    ) -> None:
+        """
+        Test that the queryset in DeletedNotificationAdmin selects related fields using `select_related`
+        to optimize query performance.
+
+        Asserts:
+        -------
+            - The queryset includes the use of `select_related` for the 'notification' and 'user' fields.
+        """
+        admin_site = admin.site
+        model_admin = DeletedNotificationAdmin(DeletedNotification, admin_site)
+        request = self.mock_request(admin_user)
+
+        queryset = model_admin.get_queryset(request)
+
+        # Check that the query uses select_related for 'notification' and 'user' fields
+        assert "notification" in str(
+            queryset.query
+        ), "'notification' field not optimized with select_related."
+        assert "user" in str(
+            queryset.query
+        ), "'user' field not optimized with select_related."

--- a/django_notification/tests/admin/test_notification_admin.py
+++ b/django_notification/tests/admin/test_notification_admin.py
@@ -1,0 +1,233 @@
+import sys
+from unittest.mock import Mock
+
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+from django.test import Client
+from django.contrib import admin
+from django_notification.models import (
+    Notification,
+    NotificationRecipient,
+    NotificationSeen,
+)
+from django_notification.admin.notification import (
+    NotificationAdmin,
+    NotificationRecipientInline,
+    NotificationSeenInline,
+)
+from django_notification.tests.constants import PYTHON_VERSION, PYTHON_VERSION_REASON
+
+pytestmark = [
+    pytest.mark.admin,
+    pytest.mark.admin_notification,
+    pytest.mark.skipif(sys.version_info < PYTHON_VERSION, reason=PYTHON_VERSION_REASON),
+]
+
+
+@pytest.mark.django_db
+class TestNotificationAdminSite:
+    """
+    Test suite for the NotificationAdmin and associated inlines in the Django admin interface.
+    """
+
+    def mock_request(self, user: User) -> Mock:
+        """
+        Create a mock request object with a user for testing.
+
+        Args:
+        ----
+            user: The user to associate with the mock request.
+
+        Returns:
+        -------
+            Mock: A mock request object with the user attribute set.
+        """
+        request = Mock()
+        request.user = user
+        return request
+
+    def test_notification_admin_list_display(
+        self, admin_user: User, notification: Notification
+    ) -> None:
+        """
+        Test that the list display fields in the NotificationAdmin interface
+        are rendered correctly in the Django admin changelist view.
+
+        Asserts:
+        -------
+            - The changelist view returns a 200 status code.
+            - The list display includes the fields 'id', 'get_title', 'is_sent', 'public', and 'timestamp'.
+        """
+        client = Client()
+        client.login(username="admin", password="password")
+
+        url = reverse("admin:django_notification_notification_changelist")
+        response = client.get(url)
+
+        assert (
+            response.status_code == 200
+        ), "Expected changelist view to return status 200."
+        content = response.content.decode()
+        assert "id" in content, "'id' field is missing in the list display."
+        assert (
+            "get_title" in content
+        ), "'get_title' field is missing in the list display."
+        assert "is_sent" in content, "'is_sent' field is missing in the list display."
+        assert "public" in content, "'public' field is missing in the list display."
+        assert (
+            "timestamp" in content
+        ), "'timestamp' field is missing in the list display."
+
+    def test_notification_admin_inlines(
+        self,
+        admin_user: User,
+        notification: Notification,
+        notification_recipient: NotificationRecipient,
+        notification_seen: NotificationSeen,
+    ) -> None:
+        """
+        Test that NotificationRecipientInline and NotificationSeenInline are correctly displayed
+        in the NotificationAdmin change form view.
+
+        Asserts:
+        -------
+            - The change form view returns a 200 status code.
+            - The change form view includes the "Notification Recipients" and "Notification Seen" sections.
+        """
+        client = Client()
+        client.login(username="admin", password="password")
+
+        url = reverse(
+            "admin:django_notification_notification_change", args=[notification.id]
+        )
+        response = client.get(url)
+
+        assert (
+            response.status_code == 200
+        ), "Expected change form view to return status 200."
+        content = response.content.decode()
+        assert (
+            "Notification Recipients" in content
+        ), "'Notification Recipients' section is missing in the change form view."
+        assert (
+            "Notification Seen" in content
+        ), "'Notification Seen' section is missing in the change form view."
+
+    def test_notification_admin_queryset(
+        self, admin_user: User, notification: Notification
+    ) -> None:
+        """
+        Test that NotificationAdmin's queryset method selects related fields using `select_related`
+        to optimize query performance.
+
+        Asserts:
+        -------
+            - The queryset includes the use of `select_related` for 'actor_content_type', 'target_content_type', and 'action_object_content_type' fields.
+        """
+        admin_site = admin.site
+        model_admin = NotificationAdmin(Notification, admin_site)
+        request = self.mock_request(admin_user)
+
+        queryset = model_admin.get_queryset(request)
+
+        # Check that the query uses select_related for specified fields
+        assert "actor_content_type" in str(
+            queryset.query
+        ), "'actor_content_type' field not optimized with select_related."
+        assert "target_content_type" in str(
+            queryset.query
+        ), "'target_content_type' field not optimized with select_related."
+        assert "action_object_content_type" in str(
+            queryset.query
+        ), "'action_object_content_type' field not optimized with select_related."
+
+    def test_notification_recipient_inline_queryset(
+        self,
+        admin_user: User,
+        notification: Notification,
+        notification_recipient: NotificationRecipient,
+    ) -> None:
+        """
+        Test that NotificationRecipientInline's queryset method selects related fields using `select_related`.
+
+        Asserts:
+        -------
+            - The queryset includes the use of `select_related` for 'notification' and 'recipient' fields.
+        """
+        admin_site = admin.site
+        inline = NotificationRecipientInline(NotificationRecipient, admin_site)
+        request = self.mock_request(admin_user)
+
+        queryset = inline.get_queryset(request)
+
+        # Check that the query uses select_related for specified fields
+        assert "notification" in str(
+            queryset.query
+        ), "'notification' field not optimized with select_related."
+        assert "recipient" in str(
+            queryset.query
+        ), "'recipient' field not optimized with select_related."
+
+    def test_notification_seen_inline_queryset(
+        self,
+        admin_user: User,
+        notification: Notification,
+        notification_seen: NotificationSeen,
+    ) -> None:
+        """
+        Test that NotificationSeenInline's queryset method selects related fields using `select_related`.
+
+        Asserts:
+        -------
+            - The queryset includes the use of `select_related` for 'notification' and 'user' fields.
+        """
+        admin_site = admin.site
+        inline = NotificationSeenInline(NotificationSeen, admin_site)
+        request = self.mock_request(admin_user)
+
+        queryset = inline.get_queryset(request)
+
+        # Check that the query uses select_related for specified fields
+        assert "notification" in str(
+            queryset.query
+        ), "'notification' field not optimized with select_related."
+        assert "user" in str(
+            queryset.query
+        ), "'user' field not optimized with select_related."
+
+    def test_mark_all_as_sent_action(
+        self, admin_user: User, notifications: list[Notification]
+    ) -> None:
+        """
+        Test the 'mark_as_sent' action in the NotificationAdmin interface for bulk marking notifications as sent.
+
+        Asserts:
+        -------
+            - The action triggers a redirect (302 status code).
+            - All selected notifications are marked as sent.
+        """
+        client = Client()
+        client.login(username="admin", password="password")
+
+        url = reverse("admin:django_notification_notification_changelist")
+        post_data = {
+            "action": "mark_as_sent",
+            "_selected_action": [
+                str(n.id) for n in notifications
+            ],  # Select all notifications
+        }
+
+        response = client.post(url, post_data)
+
+        # Check if the action was successful and redirected back
+        assert (
+            response.status_code == 302
+        ), "Expected redirect status code after action."
+
+        # Reload notifications from the database and verify that they are marked as sent
+        for notification in notifications:
+            notification.refresh_from_db()
+            assert (
+                notification.is_sent is True
+            ), f"Notification {notification.id} was not marked as sent."


### PR DESCRIPTION
🚨✅✔️ tests(admin): Add Admin Tests for NotificationAdmin and Associated inlines

- **NotificationAdmin List Display Test**:
  - Verified that the list display fields in the NotificationAdmin changelist view include id, get_title, is_sent, public, and timestamp.

- **NotificationAdmin Inlines Test**:
  - Tested that NotificationRecipientInline and NotificationSeenInline are correctly displayed in the change form view, with their respective sections visible.

- **NotificationAdmin Queryset Test**:
  - Confirmed that the get_queryset method in NotificationAdmin uses select_related for optimizing �ctor_content_type, 	arget_content_type, and action_object_content_type fields.

- **NotificationRecipientInline Queryset Test**:
  - Verified that NotificationRecipientInline uses select_related to optimize queries for the notification and recipient fields.

- **NotificationSeenInline Queryset Test**:
  - Ensured that NotificationSeenInline optimizes queries by using select_related for the notification and user fields.

- **Mark All as Sent Action Test**:
  - Tested the bulk action in the admin interface for marking all selected notifications as sent.
  - Verified that the action redirects successfully and that all selected notifications are marked as sent.


🚨✅✔️ tests(admin): Add Unit Tests for DeletedNotificationAdmin in Django Admin

- **Added Tests:**
  -  Test_deleted_notification_admin_list_display: Verifies the correct display of fields ( notification_id, get_title, get_deleted_by, deleted_at) in the changelist view.
  -  Test_deleted_notification_admin_filters: Ensures that the filters work as expected in the changelist view, especially for Deleted Notifications.
  -  Test_deleted_notification_admin_search: Tests search functionality by notification ID and the username of the user who deleted the notification.
  -  Test_deleted_notification_admin_queryset: Ensures query optimization using select_related for notification and user fields in the queryset.

- **Mocked Requests**: Used Mock to simulate admin user requests for testing.

- **Optimizations**: Verified that queries use select_related to optimize performance for related fields.

This commit improves test coverage for the DeletedNotificationAdmin class in the Django admin interface.