### PR TITLE
Tests/fixtures

### DIFF
--- a/django_notification/tests/fixtures/__init__.py
+++ b/django_notification/tests/fixtures/__init__.py
@@ -1,0 +1,19 @@
+from .notification import (
+    notification,
+    notification_dict,
+    notifications,
+    notification_seen,
+    notification_recipient,
+    deleted_notification,
+)
+from .user import (
+    admin_user,
+    qs_user,
+    group,
+    qs_group,
+    group_with_perm,
+    permission,
+    user_content_type,
+    another_user,
+    user,
+)

--- a/django_notification/tests/fixtures/notification.py
+++ b/django_notification/tests/fixtures/notification.py
@@ -1,0 +1,179 @@
+import pytest
+from django.contrib.auth.models import User, Group
+from django.contrib.contenttypes.models import ContentType
+
+from django.utils.timezone import now
+from django_notification.models import (
+    Notification,
+    NotificationSeen,
+    NotificationRecipient,
+    DeletedNotification,
+)
+from django_notification.models.helper.enums.status_choices import NotificationStatus
+
+
+from typing import Dict, Any, List
+
+
+@pytest.fixture
+def notification_dict(notification: Notification) -> Dict[str, Any]:
+    """
+    Fixture to provide a dictionary representation of a given Notification instance.
+
+    Args:
+        notification (Notification): The Notification instance to convert.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the notification's id, description,
+                        status, link, and timestamp.
+    """
+    return (
+        Notification.objects.filter(pk=notification.id)
+        .values(
+            "id",
+            "description",
+            "status",
+            "link",
+            "timestamp",
+        )
+        .first()
+    )
+
+
+@pytest.fixture
+def notification_seen(db, notification: Notification, user: User) -> NotificationSeen:
+    """
+    Fixture to create and return a NotificationSeen instance for testing.
+
+    Args:
+        db: The database fixture.
+        notification (Notification): The Notification instance associated with the seen notification.
+        user (User): The user who has seen the notification.
+
+    Returns:
+        NotificationSeen: The created NotificationSeen instance.
+    """
+    notification.recipient.add(user)
+    return NotificationSeen.objects.create(
+        notification=notification, user=user, seen_at=now()
+    )
+
+
+@pytest.fixture
+def notification_recipient(
+    db, notification: Notification, user: User
+) -> NotificationRecipient:
+    """
+    Fixture to create and return a NotificationRecipient instance for testing.
+
+    Args:
+        db: The database fixture.
+        notification (Notification): The Notification instance to which the recipient is associated.
+        user (User): The recipient of the notification.
+
+    Returns:
+        NotificationRecipient: The created NotificationRecipient instance.
+    """
+    return NotificationRecipient.objects.create(
+        notification=notification, recipient=user
+    )
+
+
+@pytest.fixture
+def notification(db, user_content_type: ContentType, user: User) -> Notification:
+    """
+    Fixture to create and return a Notification instance for testing.
+
+    Args:
+        db: The database fixture.
+        user_content_type (ContentType): The content type of the user associated with the notification.
+        user (User): The user who is the actor of the notification.
+
+    Returns:
+        Notification: The created Notification instance.
+    """
+    return Notification.objects.create(
+        verb="liked",
+        actor_content_type=user_content_type,
+        actor_object_id=user.id,
+        description="User liked a post",
+        status=NotificationStatus.INFO,
+        timestamp=now(),
+        is_sent=True,
+    )
+
+
+@pytest.fixture
+def notifications(db, user: User, qs_user: User, qs_group: Group) -> List[Notification]:
+    """
+    Fixture to create and return a list of multiple Notification instances for testing.
+
+    Args:
+        db: The database fixture.
+        user (User): The user associated with the notifications.
+        qs_user (User): Another user to be added as a recipient to the notifications.
+        qs_group (Group): A group to be added to the notifications.
+
+    Returns:
+        List[Notification]: A list of created Notification instances.
+    """
+    notifications = [
+        Notification(
+            verb="verb1",
+            actor=user,
+            description="description1",
+            status="INFO",
+            is_sent=True,
+            public=True,
+            timestamp=now(),
+        ),
+        Notification(
+            verb="verb2",
+            actor=user,
+            description="description2",
+            status="WARNING",
+            is_sent=False,
+            public=False,
+            timestamp=now(),
+        ),
+        Notification(
+            verb="verb3",
+            actor=user,
+            description="description3",
+            status="ERROR",
+            is_sent=True,
+            public=True,
+            timestamp=now(),
+        ),
+    ]
+    notifications = Notification.objects.bulk_create(notifications)
+    notifications[0].recipient.add(qs_user)
+    notifications[1].recipient.add(qs_user)
+    notifications[2].recipient.add(qs_user)
+
+    notifications[0].group.add(qs_group)
+    notifications[1].group.add(qs_group)
+    notifications[2].group.add(qs_group)
+
+    return notifications
+
+
+@pytest.fixture
+def deleted_notification(
+    db, notification: Notification, user: User
+) -> DeletedNotification:
+    """
+    Fixture to create and return a DeletedNotification instance for testing.
+
+    Args:
+        db: The database fixture.
+        notification (Notification): The Notification instance associated with the deleted notification.
+        user (User): The user who has deleted the notification.
+
+    Returns:
+        DeletedNotification: The created DeletedNotification instance.
+    """
+    notification.recipient.add(user)
+    return DeletedNotification.objects.create(
+        notification=notification, user=user, deleted_at=now()
+    )

--- a/django_notification/tests/fixtures/user.py
+++ b/django_notification/tests/fixtures/user.py
@@ -1,0 +1,136 @@
+import pytest
+from django.contrib.auth.models import User, Group, ContentType, Permission
+
+
+@pytest.fixture
+def user(db) -> User:
+    """
+    Fixture to create a standard User instance for testing.
+
+    Args:
+        db: The database fixture to set up the test database.
+
+    Returns:
+        User: The created User instance with username "testuser".
+    """
+    return User.objects.create_user(
+        username="testuser", password="12345", email="testuser@example.com"
+    )
+
+
+@pytest.fixture
+def qs_user(db) -> User:
+    """
+    Fixture to create a secondary User instance for testing.
+
+    Args:
+        db: The database fixture to set up the test database.
+
+    Returns:
+        User: The created User instance with username "queryset_user".
+    """
+    return User.objects.create_user(
+        username="queryset_user", password="12345", email="queryset_user@example.com"
+    )
+
+
+@pytest.fixture
+def admin_user(db) -> User:
+    """
+    Fixture to create a superuser with admin access for testing.
+
+    Args:
+        db: The database fixture to set up the test database.
+
+    Returns:
+        User: The created superuser with username "admin".
+    """
+    return User.objects.create_superuser(username="admin", password="password")
+
+
+@pytest.fixture
+def another_user(db) -> User:
+    """
+    Fixture to create another User instance for testing.
+
+    Args:
+        db: The database fixture to set up the test database.
+
+    Returns:
+        User: The created User instance with username "anotheruser".
+    """
+    return User.objects.create_user(
+        username="anotheruser", password="54321", email="anotheruser@example.com"
+    )
+
+
+@pytest.fixture
+def group(db) -> Group:
+    """
+    Fixture to create a Group instance for testing.
+
+    Args:
+        db: The database fixture to set up the test database.
+
+    Returns:
+        Group: The created Group instance with name "testgroup".
+    """
+    return Group.objects.create(name="testgroup")
+
+
+@pytest.fixture
+def qs_group(db) -> Group:
+    """
+    Fixture to create a secondary Group instance for testing.
+
+    Args:
+        db: The database fixture to set up the test database.
+
+    Returns:
+        Group: The created Group instance with name "queryset_group".
+    """
+    return Group.objects.create(name="queryset_group")
+
+
+@pytest.fixture
+def permission() -> Permission:
+    """
+    Fixture to create a sample Permission object for testing.
+
+
+    Returns:
+        Permission: The created Permission object with name "Can add user".
+    """
+    return Permission.objects.create(
+        name="Can add user", codename="add_user", content_type_id=1
+    )
+
+
+@pytest.fixture
+def group_with_perm(permission: Permission) -> Group:
+    """
+    Fixture to create a Group instance with a specific Permission attached.
+
+    Args:
+        permission (Permission): The Permission object to be added to the group.
+
+    Returns:
+        Group: The created Group instance with the given Permission.
+    """
+    group = Group.objects.create(name="Admins")
+    group.permissions.add(permission)
+    return group
+
+
+@pytest.fixture
+def user_content_type(db) -> ContentType:
+    """
+    Fixture to retrieve the ContentType for the User model.
+
+    Args:
+        db: The database fixture to set up the test database.
+
+    Returns:
+        ContentType: The ContentType instance for the User model.
+    """
+    return ContentType.objects.get_for_model(User)


### PR DESCRIPTION
✨🚨 feat(tests): Add Fixtures for Testing Notification Models
This commit introduces new fixtures to support testing of notification-related models in the django_notification application. These fixtures provide standardized instances and data setups for various tests.

#### Added Fixtures:
- **notification_dict**: Converts a Notification instance to a dictionary representation containing fields like id, description, status, link, and timestamp.

- **notification_seen**: Creates and returns a NotificationSeen instance, associating a given Notification with a user and setting the seen_at timestamp.

- **notification_recipient**: Creates and returns a NotificationRecipient instance, associating a given Notification with a recipient user.

- **notification**: Creates and returns a single Notification instance, including required fields such as �erb, �ctor, description, and status.

- **notifications**: Creates and returns a list of multiple Notification instances with various statuses and descriptions. Includes setup for recipients and groups.

- **deleted_notification**: Creates and returns a DeletedNotification instance, associating a given Notification with a user and setting the deleted_at timestamp.

#### Improvements:
- Added type annotations for better clarity and type checking.
- Enhanced docstrings to describe the purpose and usage of each fixture, including arguments and return types.

These additions will streamline test setup and ensure consistency across tests involving notification models.

✨🚨 feat(tests): Add User, Group, and Permission Fixtures for Testing
 This commit introduces new fixtures to support testing with user, group, and permission-related models. These fixtures facilitate the creation of various instances needed for comprehensive testing.

 #### Added Fixtures:
 - **user**: Creates and returns a standard User instance with the username 'testuser', email 'testuser@example.com', and password '12345'.

 - **qs_user**: Creates and returns a secondary User instance with the username 'queryset_user', email 'queryset_user@example.com', and password '12345'.

 - **admin_user**: Creates and returns a superuser with admin access, using the username 'admin' and password 'password'.

 - **another_user**: Creates and returns an additional User instance with the username 'anotheruser', email 'anotheruser@example.com', and password '54321'.

 - **group**: Creates and returns a Group instance with the name 'testgroup'.

 - **qs_group**: Creates and returns a secondary Group instance with the name 'queryset_group'.

 - **permission**: Creates and returns a sample Permission object with the name 'Can add user' and codename 'add_user'.

 - **group_with_perm**: Creates and returns a Group instance with the provided Permission attached, named 'Admins'.

 - **user_content_type**: Retrieves and returns the ContentType instance for the User model.

 #### Improvements:
 - Added type annotations for each fixture for better clarity and type checking.
 - Enhanced docstrings to describe the purpose and return values of each fixture, including arguments where applicable.

These fixtures will streamline the setup process for tests involving users, groups, and permissions, ensuring consistent and reliable test environments.
Closes https://github.com/Lazarus-org/dj-notification-api/issues/41